### PR TITLE
Add storage support for QML

### DIFF
--- a/samples/qml/metrics.js
+++ b/samples/qml/metrics.js
@@ -2,9 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-.import "../../dist/glean.js" as GleanInstance;
-
-const Glean = new GleanInstance.Glean.Glean("qml-sample-app", "qml")
+const Glean = new GleanInstance.Glean.Glean("qml-sample-app", "QML")
 const Metrics = {
     test: new GleanInstance.Glean._MetricTypes.EventMetricType(Glean, "testcat", "click"),
 };

--- a/samples/qml/view.qml
+++ b/samples/qml/view.qml
@@ -6,6 +6,7 @@ import QtQuick 2.0
 import QtQuick.Controls 2.0
 import QtQuick.LocalStorage 2.0
 
+import "../../dist/glean.js" as GleanInstance;
 import "./metrics.js" as Glean;
 
 Rectangle {

--- a/samples/qml/view.qml
+++ b/samples/qml/view.qml
@@ -6,6 +6,9 @@ import QtQuick 2.0
 import QtQuick.Controls 2.0
 import QtQuick.LocalStorage 2.0
 
+// Even though GleanInstance will only be used inside metrics.js,
+// we need to import it here because otherwise glean.js doesn't
+// have access to LocalStorage.
 import "../../dist/glean.js" as GleanInstance;
 import "./metrics.js" as Glean;
 

--- a/src/storage/qml.js
+++ b/src/storage/qml.js
@@ -4,6 +4,13 @@
 
 const DB_NAME = "Glean";
 
+// Initiallize I had created a QMLStorage class here,
+// that would create the table if it doesn't exist on init
+// and exposed the `getItem` and `setItem` API.
+//
+// For some reason, that generated QML errors, saying that `this` was undefined.
+// Those errors only happened on the `getItem` and `setItem` functions, I am not sure the cause.
+
 // Initialize the database ASAP.
 _executeQuery(`CREATE TABLE IF NOT EXISTS ${DB_NAME}(key TEXT, value TEXT);`);
 

--- a/src/storage/qml.js
+++ b/src/storage/qml.js
@@ -2,8 +2,58 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-module.exports = {
-    getItem(key) { },
+const DB_NAME = "Glean";
 
-    setItem(key, value) { }
+// Initialize the database ASAP.
+_executeQuery(`CREATE TABLE IF NOT EXISTS ${DB_NAME}(key TEXT, value TEXT);`);
+
+// For debugging purposes: clear the db on init.
+// _executeQuery(`DELETE FROM ${DB_NAME};`);
+
+// This allows for `REPLACE ITEM` to work.
+// See: https://www.sqlitetutorial.net/sqlite-replace-statement/
+_executeQuery(`CREATE UNIQUE INDEX IF NOT EXISTS idx ON ${DB_NAME}(key);`)
+
+function _getDbHandle() {
+    return LocalStorage.openDatabaseSync(DB_NAME, "1.0", `${DB_NAME} Storage`, 1000000);
 }
+
+function _executeQuery(query) {
+    const handle = _getDbHandle();
+    console.info(`Attempting to execute query: ${query}`);
+
+    let rs;
+    try {
+        handle.transaction(tx => {
+            rs = tx.executeSql(query);
+        })
+    } catch (err) {
+        console.error(`Error executing query! ${err}`);
+    }
+
+    return rs;
+}
+
+module.exports = {
+    getItem(key) {
+        let result;
+        const rs = _executeQuery(`SELECT key, value FROM ${DB_NAME} WHERE key='${key}';`);
+        if (rs.rows.length === 0) {
+            result = null;
+        } else if (rs.rows.length > 1) {
+            console.error("Duplicate rows in database, something went wrong. Entries:");
+            for (let i = 0; i < rs.rows.length; i++) {
+                console.info(`key: ${rs.rows.item(i).key}, value: ${rs.rows.item(i).value}`)
+            }
+            result = null;
+        } else {
+            result = rs.rows.item(0).value;
+        }
+
+        return result;
+    },
+
+    setItem(key, value) {
+        _executeQuery(`REPLACE INTO ${DB_NAME}(key, value) VALUES('${key}', '${value}');`);
+    }
+};


### PR DESCRIPTION
I make a little hack so that the underlying SQLite database could easily have the same API as localStorage in the browser.

I create a table in SQLite, the Glean table, which has only two columns `key` and `value`. Please let me know if that is a terrible idea :)